### PR TITLE
test: fix expired GovObject proposal fixtures

### DIFF
--- a/test/govobject/govobject.js
+++ b/test/govobject/govobject.js
@@ -18,6 +18,16 @@ var BufferReader = require('../../lib/encoding/bufferreader');
 /* FromObject */
 describe('GovObject', function () {
   describe('GovObject - FromObject', function () {
+    var clock;
+
+    before(function () {
+      clock = sinon.useFakeTimers(new Date('2024-01-01T00:00:00Z').getTime());
+    });
+
+    after(function () {
+      clock.restore();
+    });
+
     it('should cast a JSON Proposal into a Proposal Object', function () {
       var govObject = new GovObject();
       var jsonProposal = {

--- a/test/govobject/types/proposal.js
+++ b/test/govobject/types/proposal.js
@@ -20,6 +20,7 @@ var errors = bitcore.errors;
 // TODO: create Proposal from object
 
 describe('Proposal', function () {
+  var clock;
   var startDate = Math.round(new Date('2015-10-10').getTime() / 1000);
   var endDate = Math.round(new Date('2025-10-10').getTime() / 1000);
   var validJSONProposal = {
@@ -32,6 +33,15 @@ describe('Proposal', function () {
     type: 1,
     url: 'http://www.dash.org',
   };
+
+  before(function () {
+    clock = sinon.useFakeTimers(new Date('2024-01-01T00:00:00Z').getTime());
+  });
+
+  after(function () {
+    clock.restore();
+  });
+
   it('should create new proposal', function () {
     var proposal = new Proposal();
 


### PR DESCRIPTION
# Fix expired GovObject proposal fixtures

## Summary

- Freeze the affected GovObject/Proposal test suites' clock at
  `2024-01-01T00:00:00Z`.
- Keep the historical `2025-10-10` proposal fixture valid without changing
  serialized fixture hex.
- Avoid production-code changes; this only restores deterministic tests for the
  existing fixture data.

## Validation

- `npm run test:node -- --grep 'GovObject|Proposal'` -> 50 passing
- `npm run test:node` -> 3509 passing, 17 pending
- `npm test` was also attempted locally, but the browser/Karma phase cannot
  launch Firefox in this environment:
  `No binary for Firefox browser on your platform`. The node test phase is
  covered above.

## Review

- Pre-PR code review gate: ship


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite timing controls to improve reliability of time-dependent test scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/dashcore-lib/pull/316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->